### PR TITLE
Revert "Work around debugpy wheel issue"

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[installer]
-modern-installation = false


### PR DESCRIPTION
It worked around a combination of bugs, including a bug in Poetry 1.4.1.

Poetry 1.4.2 has been released, fixing the Poetry bug, so this should no longer be needed (and it is better to get the warning about the broken dependency wheel):

https://github.com/python-poetry/poetry/releases/tag/1.4.2

This reverts commit 7344127871c99488cdd2fb804c4cbafe1dff2761.