### PR TITLE
Use pipx to install poetry on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: flake8 Lint
         uses: py-actions/flake8@v2
@@ -28,11 +28,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
-      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py | python3 -
+        run: pipx install poetry
 
       - name: Install project
         run: poetry install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,6 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        include:
-          - poetry: ~/.local/bin/poetry
-
-          - os: windows
-            poetry: |-
-              "$APPDATA/Python/Scripts/poetry"
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -33,20 +27,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: |
-          curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py |
-              python -
+        run: pipx install poetry
 
       - name: Install project and test runner
-        run: ${{ matrix.poetry }} install
+        run: poetry install
 
       - name: Print Python version
-        run: ${{ matrix.poetry }} run python -V
+        run: poetry run python -V
 
       - name: Run Unit Tests
-        run: ${{ matrix.poetry }} run pytest
+        run: poetry run pytest
 
   test-conda:
     name: Test (conda)

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,11 +13,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: '3.11'
 
-      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py | python3 -
+        run: pipx install poetry
 
       - name: Generate requirements.txt
         run: poetry export --with dev >requirements.txt
@@ -25,8 +24,8 @@ jobs:
       - name: mypy Typecheck
         uses: jpetrucciani/mypy-check@1.2.0
         with:
-          python_version: "3.11"
-          requirements_file: "requirements.txt"
+          python_version: '3.11'
+          requirements_file: 'requirements.txt'
 
   pyright:
     runs-on: ubuntu-latest
@@ -38,14 +37,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: '3.11'
 
       - name: Upgrade PyPA packages
         run: python -m pip install -U pip setuptools wheel
 
-      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py | python3 -
+        run: pipx install poetry
 
       - name: Generate requirements.txt
         run: poetry export --with dev >requirements.txt


### PR DESCRIPTION
Instead of the install.python-poetry.org script.

Other changes:

- Made quoting style in CI workflow YAML files to be consistent.

- Specifies all versions as strings.

  (3.11 can be specified as a float. but 3.10 couldn't, since it's converted to a string like 3.1, so it's best to quote the versions.)