### PR TITLE
Revert "Use pipx to install poetry on CI"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: flake8 Lint
         uses: py-actions/flake8@v2
@@ -28,10 +28,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
+      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: pipx install poetry
+        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py | python3 -
 
       - name: Install project
         run: poetry install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,12 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        include:
+          - poetry: ~/.local/bin/poetry
+
+          - os: windows
+            poetry: |-
+              "$APPDATA/Python/Scripts/poetry"
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -27,17 +33,20 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: pipx install poetry
+        run: |
+          curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py |
+              python -
 
       - name: Install project and test runner
-        run: poetry install
+        run: ${{ matrix.poetry }} install
 
       - name: Print Python version
-        run: poetry run python -V
+        run: ${{ matrix.poetry }} run python -V
 
       - name: Run Unit Tests
-        run: poetry run pytest
+        run: ${{ matrix.poetry }} run pytest
 
   test-conda:
     name: Test (conda)

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,10 +13,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: 3.11
 
+      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: pipx install poetry
+        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py | python3 -
 
       - name: Generate requirements.txt
         run: poetry export --with dev >requirements.txt
@@ -24,8 +25,8 @@ jobs:
       - name: mypy Typecheck
         uses: jpetrucciani/mypy-check@1.2.0
         with:
-          python_version: '3.11'
-          requirements_file: 'requirements.txt'
+          python_version: "3.11"
+          requirements_file: "requirements.txt"
 
   pyright:
     runs-on: ubuntu-latest
@@ -37,13 +38,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: 3.11
 
       - name: Upgrade PyPA packages
         run: python -m pip install -U pip setuptools wheel
 
+      # TODO: Print the install script commit hash and Poetry version.
       - name: Install poetry
-        run: pipx install poetry
+        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/b64s/install-poetry.py | python3 -
 
       - name: Generate requirements.txt
         run: poetry export --with dev >requirements.txt


### PR DESCRIPTION
Reverts EliahKagan/b64s#20

With pipx, the test runner's Python 3.10 was being used, rather than the version installed by the setup-python action.

This could probably be addressed by running `poetry env use ...` with `...` as the version. For now, though, I'm just reverting the change.