### PR TITLE
Use explicit version string for CI poetry env

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      - name: Configure poetry to use the python from setup-python
-        run: poetry env use python
+      - name: Configure the poetry environment
+        run: poetry env use 3.11
 
       - name: Install project
         run: poetry install --only=main,analyze,test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      - name: Configure poetry to use the python from setup-python
-        run: poetry env use python
+      - name: Configure the poetry environment
+        run: poetry env use ${{ matrix.python-version }}
 
       - name: Install project and test runner
         run: poetry install --only=main,test


### PR DESCRIPTION
There's no need for the weird `poetry env use python` command I was using, because `poetry env use` understands Python version strings of the form `setup-python` accepts.