### PR TITLE
Migrate to setup-micromamba

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,8 +84,10 @@ jobs:
           perl -i -spwe 's/^ *- python=\K.+$/$pyver/' -- \
               -pyver=${{ matrix.python-version }} environment.yml
 
-      - name: Provision with micromamba
-        uses: mamba-org/provision-with-micromamba@v16
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
 
       - name: Print Python version
         run: python -V


### PR DESCRIPTION
Since provision-with-micromamba is now deprecated.

See:

- https://github.com/mamba-org/provision-with-micromamba/releases/tag/v16
- https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba
- https://github.com/mamba-org/setup-micromamba