### PR TITLE
Revert "Have Dependabot group Python dependencies (#48)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     allow:
       - dependency-type: all
     open-pull-requests-limit: 20
-    groups:
-      python-dependencies:
-        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Not all available updates were being included.

This reverts commit 3b11b03bf94d2b82e5f2b2fa354960f0888f2ab3.