### PR TITLE
Revert "Revert "Have Dependabot group Python dependencies (#48)" (#53)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     allow:
       - dependency-type: all
     open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Let's try it again now.

This reverts commit 00dae6433f3d26dd895973833a01110752b0adc4.